### PR TITLE
Linux .so only exports needed symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ set(CMAKE_BUILD_TYPE Release)
 ADD_DEFINITIONS(-DUNICODE)
 ADD_DEFINITIONS(-D_UNICODE)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 -D_UNICODE -DUNICODE")
+if (UNIX)
+    set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+endif(UNIX)
 set(CMAKE_LINK_DEF_FILE_FLAG Pokopom/Exports.def)
 
 set(SOURCE_FILES
@@ -48,10 +51,12 @@ set(SOURCE_FILES
         Pokopom/Zilmar.cpp
         Pokopom/Zilmar_Controller_Interface.h
         Pokopom/Zilmar_Devices.cpp
-        Pokopom/Zilmar_Devices.h)
+        Pokopom/Zilmar_Devices.h
+        SCP/SCPExtensions.cpp
+        SCP/SCPExtensions.h)
 
 add_library(padPokopom SHARED ${SOURCE_FILES})
 set(CMAKE_EXE_LINKER_FLAGS " -static")
 if(WIN32)
-target_link_libraries(padPokopom UxTheme.lib)
+    target_link_libraries(padPokopom UxTheme.lib)
 endif(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,9 +51,7 @@ set(SOURCE_FILES
         Pokopom/Zilmar.cpp
         Pokopom/Zilmar_Controller_Interface.h
         Pokopom/Zilmar_Devices.cpp
-        Pokopom/Zilmar_Devices.h
-        SCP/SCPExtensions.cpp
-        SCP/SCPExtensions.h)
+        Pokopom/Zilmar_Devices.h)
 
 add_library(padPokopom SHARED ${SOURCE_FILES})
 set(CMAKE_EXE_LINKER_FLAGS " -static")

--- a/Pokopom/General.h
+++ b/Pokopom/General.h
@@ -30,7 +30,7 @@
 	#include <X11/Xlib.h>
 
 	#ifdef __cplusplus
-	#define DllExport extern "C" __attribute__((stdcall))
+	#define DllExport extern "C" __attribute__((stdcall)) __attribute__((visibility ("default")))
 	#else
 	#define DllExport __attribute__((stdcall))
 	#endif

--- a/Pokopom/General.h
+++ b/Pokopom/General.h
@@ -30,7 +30,7 @@
 	#include <X11/Xlib.h>
 
 	#ifdef __cplusplus
-	#define DllExport extern "C" __attribute__((stdcall)) __attribute__((visibility ("default")))
+	#define DllExport extern "C" __attribute__((stdcall, visibility ("default")))
 	#else
 	#define DllExport __attribute__((stdcall))
 	#endif


### PR DESCRIPTION
Set the default visibility in cmake to hidden, and added an attribute to the DllExport macro to mark those functions as visible. This may be a bug or it may be normal, but for some reason the following symbols are also exported:

![image](https://cloud.githubusercontent.com/assets/5447759/23328043/e6596838-fae6-11e6-88fb-d570cdc065d2.png)
